### PR TITLE
Handle relativeURI recursives to empty string in checkGetRelativeURL

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -104,11 +104,15 @@ func getRelativeURL(absURL string) string {
 // checkGetRelativeURL checks if URL is relative, prepends relative part if missed
 func checkGetRelativeURL(relativeURI string, ctxURL string) string {
 	// Prepend web relative URL to "Lists/ListPath" URIs
-	if string([]rune(relativeURI)[0]) != "/" {
-		absoluteURL := getPriorEndpoint(ctxURL, "/_api")
-		relativeURL := getRelativeURL(absoluteURL)
-		relativeURI = fmt.Sprintf("%s/%s", relativeURL, relativeURI)
+
+	if relativeURI != "" {
+		if string([]rune(relativeURI)[0]) != "/" {
+			absoluteURL := getPriorEndpoint(ctxURL, "/_api")
+			relativeURL := getRelativeURL(absoluteURL)
+			relativeURI = fmt.Sprintf("%s/%s", relativeURL, relativeURI)
+		}
 	}
+
 	return relativeURI
 }
 


### PR DESCRIPTION
When the site url does not have .com in hostname, the string relativeURI somehow becomes an empty string and the program panics at checkGetRelativeURL because `[]rune(relativeURI)[0]` is null, so I tried to handle empty relativeURI