### PR TITLE
Adding `#` cases to `EscapePathURI`

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -74,6 +74,7 @@ func ExtractEntityURI(payload []byte) string {
 func EscapePathURI(s string) string {
 	s = strings.Replace(s, "'", "''", -1)
 	s = strings.Replace(s, "%", "%25", -1)
+	s = strings.Replace(s, "#", "%23", -1)
 	return s
 }
 


### PR DESCRIPTION
I'm adding to `EscapePathURI` a replacement to  `#` (similar issue of #80 and #78) 