### PR TITLE
`AddChunked` Causing Incomplete File Uploads

### DIFF
--- a/api/filesChunked.go
+++ b/api/filesChunked.go
@@ -65,7 +65,7 @@ func (files *Files) AddChunked(name string, stream io.Reader, options *AddChunke
 
 	slot := make([]byte, options.ChunkSize)
 	for {
-		size, err := stream.Read(slot)
+		size, err := io.ReadFull(stream, slot)
 		if err == io.EOF {
 			break
 		}


### PR DESCRIPTION
The PR fixes  #85

Instead of using `stream.Read(slot)`, which doesn't guarantee `size == len(slot)`, you can use `io.ReadFull`, which ensures that it fills the entire buffer unless an error occurs. This way, the function won't mistakenly assume the upload is complete when it has only received a partial read.
