### PR TITLE
feat: add support for site enumeration via the GetSitePropertiesFromSharePointByFilters SPO Tenant Admin API (CSOM) method.

### DIFF
--- a/api/sp.go
+++ b/api/sp.go
@@ -76,6 +76,12 @@ func (sp *SP) Taxonomy() *Taxonomy {
 	return NewTaxonomy(sp.client, sp.ToURL(), sp.config)
 }
 
+// SPOTenant getter for querying site properties via Tenant Administration CSOM API.
+// SP instance should target the tenant admin site URL (e.g., https://contoso-admin.sharepoint.com).
+func (sp *SP) SPOTenant() *SPOTenant {
+	return NewSPOTenant(sp.client, sp.ToURL(), sp.config)
+}
+
 // ContextInfo gets current Context Info object data
 func (sp *SP) ContextInfo() (*ContextInfo, error) {
 	return NewContext(sp.client, sp.ToURL(), sp.config).Get()

--- a/api/spotenant.go
+++ b/api/spotenant.go
@@ -1,0 +1,409 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/koltyakov/gosip"
+	"github.com/koltyakov/gosip/csom"
+)
+
+// SPOTenant represents SharePoint Online Tenant Administration API
+// Always use NewSPOTenant constructor instead of &SPOTenant{}
+type SPOTenant struct {
+	client   *HTTPClient
+	config   *RequestConfig
+	endpoint string
+}
+
+// NewSPOTenant creates a new SPOTenant API instance
+func NewSPOTenant(client *gosip.SPClient, siteURL string, config *RequestConfig) *SPOTenant {
+	return &SPOTenant{
+		client:   NewHTTPClient(client),
+		endpoint: siteURL,
+		config:   config,
+	}
+}
+
+// Conf sets request config for the current chain
+func (t *SPOTenant) Conf(config *RequestConfig) *SPOTenant {
+	t.config = config
+	return t
+}
+
+// IncludePersonalSite controls whether OneDrive personal sites appear
+// in tenant site property queries.
+
+// IncludePersonalSiteDefault uses the server default (excludes personal sites)
+// IncludePersonalSiteInclude includes personal sites
+// IncludePersonalSiteOnly returns only personal sites
+type IncludePersonalSite int
+
+const (
+	IncludePersonalSiteDefault IncludePersonalSite = 0
+	IncludePersonalSiteInclude IncludePersonalSite = 1
+	IncludePersonalSiteOnly IncludePersonalSite = 2
+)
+
+// SitePropertiesFilter defines the filter parameters for GetSitePropertiesFromSharePointByFilters
+type SitePropertiesFilter struct {
+
+	// CSOM filter expression (e.g., "Url -like 'tenant-my.sharepoint.com/personal/'")
+	Filter string
+
+	// IncludeDetail requests the full set of site properties. When false,
+	// some properties may return server defaults rather than actual values
+	IncludeDetail bool
+
+	// Site template filter
+	// (e.g., use "SPSPERS" for OneDrive personal sites)
+	Template string
+
+	// IncludePersonalSite controls whether OneDrive personal sites appear in results.
+	// Valid values: IncludePersonalSiteDefault (0), IncludePersonalSiteInclude (1), IncludePersonalSiteOnly (2).
+	IncludePersonalSite IncludePersonalSite
+}
+
+// SitePropertiesPage represents a page of site property results
+type SitePropertiesPage struct {
+	Sites       []SitePropertiesResp
+	HasNextPage func() bool
+	GetNextPage func() (*SitePropertiesPage, error)
+}
+
+// SitePropertiesResp represents a single sites raw CSOM JSON response
+type SitePropertiesResp []byte
+
+// Data unmarshals the response into a typed SiteProperties struct
+func (r SitePropertiesResp) Data() *SiteProperties {
+	var sp SiteProperties
+	if err := json.Unmarshal(r, &sp); err != nil {
+		return &SiteProperties{}
+	}
+	return &sp
+}
+
+// Normalized returns the raw JSON bytes for custom unmarshalling
+func (r SitePropertiesResp) Normalized() []byte {
+	return []byte(r)
+}
+
+// SiteProperties holds site metadata returned by CSOM tenant queries.
+// Fields map to Microsoft.Online.SharePoint.TenantAdministration.SiteProperties.
+type SiteProperties struct {
+	AllowDownloadingNonWebViewableFiles                        bool        `json:"AllowDownloadingNonWebViewableFiles"`
+	AllowEditing                                               bool        `json:"AllowEditing"`
+	AllowFileArchive                                           bool        `json:"AllowFileArchive"`
+	AllowSelfServiceUpgrade                                    bool        `json:"AllowSelfServiceUpgrade"`
+	AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled bool     `json:"AllowWebPropertyBagUpdateWhenDenyAddAndCustomizePagesIsEnabled"`
+	AnonymousLinkExpirationInDays                              int         `json:"AnonymousLinkExpirationInDays"`
+	ApplyToExistingDocumentLibraries                           bool        `json:"ApplyToExistingDocumentLibraries"`
+	ApplyToNewDocumentLibraries                                bool        `json:"ApplyToNewDocumentLibraries"`
+	ArchiveStatus                                              string      `json:"ArchiveStatus"`
+	ArchivedBy                                                 string      `json:"ArchivedBy"`
+	ArchivedFileDiskUsed                                       int64       `json:"ArchivedFileDiskUsed"`
+	ArchivedTime                                               string      `json:"ArchivedTime"`
+	AuthContextStrength                                        *string     `json:"AuthContextStrength"`
+	AuthenticationContextLimitedAccess                         bool        `json:"AuthenticationContextLimitedAccess"`
+	AuthenticationContextName                                  *string     `json:"AuthenticationContextName"`
+	AverageResourceUsage                                       int         `json:"AverageResourceUsage"`
+	BlockDownloadLinksFileType                                 int         `json:"BlockDownloadLinksFileType"`
+	BlockDownloadMicrosoft365GroupIds                           []string    `json:"BlockDownloadMicrosoft365GroupIds"`
+	BlockDownloadPolicy                                        bool        `json:"BlockDownloadPolicy"`
+	BlockDownloadPolicyFileTypeIds                             []int       `json:"BlockDownloadPolicyFileTypeIds"`
+	BlockGuestsAsSiteAdmin                                     int         `json:"BlockGuestsAsSiteAdmin"`
+	BonusDiskQuota                                             int64       `json:"BonusDiskQuota"`
+	ClearGroupId                                               bool        `json:"ClearGroupId"`
+	ClearRestrictedAccessControl                               bool        `json:"ClearRestrictedAccessControl"`
+	CommentsOnSitePagesDisabled                                bool        `json:"CommentsOnSitePagesDisabled"`
+	CompatibilityLevel                                         int         `json:"CompatibilityLevel"`
+	ConditionalAccessPolicy                                    int         `json:"ConditionalAccessPolicy"`
+	CreatedTime                                                string      `json:"CreatedTime"`
+	CurrentResourceUsage                                       int         `json:"CurrentResourceUsage"`
+	DefaultLinkPermission                                      int         `json:"DefaultLinkPermission"`
+	DefaultLinkToExistingAccess                                bool        `json:"DefaultLinkToExistingAccess"`
+	DefaultLinkToExistingAccessReset                           bool        `json:"DefaultLinkToExistingAccessReset"`
+	DefaultShareLinkRole                                       int         `json:"DefaultShareLinkRole"`
+	DefaultShareLinkScope                                      int         `json:"DefaultShareLinkScope"`
+	DefaultSharingLinkType                                     int         `json:"DefaultSharingLinkType"`
+	DenyAddAndCustomizePages                                   int         `json:"DenyAddAndCustomizePages"`
+	Description                                                *string     `json:"Description"`
+	DisableAppViews                                            int         `json:"DisableAppViews"`
+	DisableClassicPageBaselineSecurityMode                     bool        `json:"DisableClassicPageBaselineSecurityMode"`
+	DisableCompanyWideSharingLinks                             int         `json:"DisableCompanyWideSharingLinks"`
+	DisableFlows                                               int         `json:"DisableFlows"`
+	DisableSiteBranding                                        bool        `json:"DisableSiteBranding"`
+	EnableAutoExpirationVersionTrim                            bool        `json:"EnableAutoExpirationVersionTrim"`
+	ExcludeBlockDownloadPolicySiteOwners                       bool        `json:"ExcludeBlockDownloadPolicySiteOwners"`
+	ExcludeBlockDownloadSharePointGroups                       []string    `json:"ExcludeBlockDownloadSharePointGroups"`
+	ExcludedBlockDownloadGroupIds                              []string    `json:"ExcludedBlockDownloadGroupIds"`
+	ExpireVersionsAfterDays                                    int         `json:"ExpireVersionsAfterDays"`
+	ExternalUserExpirationInDays                               int         `json:"ExternalUserExpirationInDays"`
+	FileTypesForVersionExpiration                              *string     `json:"FileTypesForVersionExpiration"`
+	GroupId                                                    string      `json:"GroupId"`
+	GroupOwnerLoginName                                        *string     `json:"GroupOwnerLoginName"`
+	HasHolds                                                   bool        `json:"HasHolds"`
+	HidePeoplePreviewingFiles                                  bool        `json:"HidePeoplePreviewingFiles"`
+	HidePeopleWhoHaveListsOpen                                 bool        `json:"HidePeopleWhoHaveListsOpen"`
+	HubSiteId                                                  string      `json:"HubSiteId"`
+	IBMode                                                     *string     `json:"IBMode"`
+	IBSegments                                                 []string    `json:"IBSegments"`
+	IBSegmentsToAdd                                            []string    `json:"IBSegmentsToAdd"`
+	IBSegmentsToRemove                                         []string    `json:"IBSegmentsToRemove"`
+	InheritVersionPolicyFromTenant                             bool        `json:"InheritVersionPolicyFromTenant"`
+	IsAuthoritative                                            bool        `json:"IsAuthoritative"`
+	IsGroupOwnerSiteAdmin                                      bool        `json:"IsGroupOwnerSiteAdmin"`
+	IsHubSite                                                  bool        `json:"IsHubSite"`
+	IsTeamsChannelConnected                                    bool        `json:"IsTeamsChannelConnected"`
+	IsTeamsConnected                                           bool        `json:"IsTeamsConnected"`
+	LastContentModifiedDate                                    string      `json:"LastContentModifiedDate"`
+	Lcid                                                       int         `json:"Lcid"`
+	LimitedAccessFileType                                      int         `json:"LimitedAccessFileType"`
+	ListsShowHeaderAndNavigation                               bool        `json:"ListsShowHeaderAndNavigation"`
+	LockIssue                                                  *string     `json:"LockIssue"`
+	LockReason                                                 int         `json:"LockReason"`
+	LockState                                                  string      `json:"LockState"`
+	LoopDefaultSharingLinkRole                                 int         `json:"LoopDefaultSharingLinkRole"`
+	LoopDefaultSharingLinkScope                                int         `json:"LoopDefaultSharingLinkScope"`
+	MajorVersionLimit                                          int         `json:"MajorVersionLimit"`
+	MajorWithMinorVersionsLimit                                int         `json:"MajorWithMinorVersionsLimit"`
+	MediaTranscription                                         int         `json:"MediaTranscription"`
+	OrganizationLinkMaxExpirationInDays                        int         `json:"OrganizationLinkMaxExpirationInDays"`
+	OrganizationLinkRecommendedExpirationInDays                int         `json:"OrganizationLinkRecommendedExpirationInDays"`
+	OverrideBlockUserInfoVisibility                            int         `json:"OverrideBlockUserInfoVisibility"`
+	OverrideSharingCapability                                  bool        `json:"OverrideSharingCapability"`
+	OverrideTenantAnonymousLinkExpirationPolicy                bool        `json:"OverrideTenantAnonymousLinkExpirationPolicy"`
+	OverrideTenantExternalUserExpirationPolicy                 bool        `json:"OverrideTenantExternalUserExpirationPolicy"`
+	OverrideTenantOrganizationLinkExpirationPolicy             bool        `json:"OverrideTenantOrganizationLinkExpirationPolicy"`
+	Owner                                                      string      `json:"Owner"`
+	OwnerEmail                                                 *string     `json:"OwnerEmail"`
+	OwnerLoginName                                             *string     `json:"OwnerLoginName"`
+	OwnerName                                                  *string     `json:"OwnerName"`
+	PWAEnabled                                                 int         `json:"PWAEnabled"`
+	ReadOnlyAccessPolicy                                       bool        `json:"ReadOnlyAccessPolicy"`
+	ReadOnlyForBlockDownloadPolicy                             bool        `json:"ReadOnlyForBlockDownloadPolicy"`
+	ReadOnlyForUnmanagedDevices                                bool        `json:"ReadOnlyForUnmanagedDevices"`
+	RelatedGroupId                                             string      `json:"RelatedGroupId"`
+	RemoveVersionExpirationFileTypeOverride                    *string     `json:"RemoveVersionExpirationFileTypeOverride"`
+	RequestFilesLinkEnabled                                    bool        `json:"RequestFilesLinkEnabled"`
+	RequestFilesLinkExpirationInDays                           int         `json:"RequestFilesLinkExpirationInDays"`
+	RestrictContentOrgWideSearch                               bool        `json:"RestrictContentOrgWideSearch"`
+	RestrictedAccessControl                                    bool        `json:"RestrictedAccessControl"`
+	RestrictedAccessControlGroups                              []string    `json:"RestrictedAccessControlGroups"`
+	RestrictedAccessControlGroupsToAdd                         []string    `json:"RestrictedAccessControlGroupsToAdd"`
+	RestrictedAccessControlGroupsToRemove                      []string    `json:"RestrictedAccessControlGroupsToRemove"`
+	RestrictedContentDiscoveryForCopilotAndAgents              bool        `json:"RestrictedContentDiscoveryforCopilotAndAgents"`
+	RestrictedToRegion                                         int         `json:"RestrictedToRegion"`
+	SandboxedCodeActivationCapability                          int         `json:"SandboxedCodeActivationCapability"`
+	SensitivityLabel                                           string      `json:"SensitivityLabel"`
+	SensitivityLabel2                                          *string     `json:"SensitivityLabel2"`
+	SetOwnerWithoutUpdatingSecondaryAdmin                      bool        `json:"SetOwnerWithoutUpdatingSecondaryAdmin"`
+	SharingAllowedDomainList                                   *string     `json:"SharingAllowedDomainList"`
+	SharingBlockedDomainList                                   *string     `json:"SharingBlockedDomainList"`
+	SharingCapability                                          int         `json:"SharingCapability"`
+	SharingDomainRestrictionMode                               int         `json:"SharingDomainRestrictionMode"`
+	SharingLockDownCanBeCleared                                bool        `json:"SharingLockDownCanBeCleared"`
+	SharingLockDownEnabled                                     bool        `json:"SharingLockDownEnabled"`
+	ShowPeoplePickerSuggestionsForGuestUsers                   bool        `json:"ShowPeoplePickerSuggestionsForGuestUsers"`
+	SiteDefinedSharingCapability                               int         `json:"SiteDefinedSharingCapability"`
+	SiteID                                                     string      `json:"SiteId"`
+	SocialBarOnSitePagesDisabled                               bool        `json:"SocialBarOnSitePagesDisabled"`
+	Status                                                     string      `json:"Status"`
+	StorageMaximumLevel                                        int64       `json:"StorageMaximumLevel"`
+	StorageQuotaType                                           *string     `json:"StorageQuotaType"`
+	StorageUsage                                               int64       `json:"StorageUsage"`
+	StorageWarningLevel                                        int64       `json:"StorageWarningLevel"`
+	TeamsChannelType                                           int         `json:"TeamsChannelType"`
+	Template                                                   string      `json:"Template"`
+	TimeZoneId                                                 int         `json:"TimeZoneId"`
+	Title                                                      string      `json:"Title"`
+	TitleTranslations                                          []string    `json:"TitleTranslations"`
+	URL                                                        string      `json:"Url"`
+	UserCodeMaximumLevel                                       int         `json:"UserCodeMaximumLevel"`
+	UserCodeWarningLevel                                       int         `json:"UserCodeWarningLevel"`
+	VersionCount                                               int         `json:"VersionCount"`
+	VersionPolicyFileTypeOverride                              []string    `json:"VersionPolicyFileTypeOverride"`
+	VersionSize                                                int64       `json:"VersionSize"`
+	WebsCount                                                  int         `json:"WebsCount"`
+}
+
+// CreatedTimeDate parses CreatedTime from CSOM date format into time.Time.
+// Returns the zero time if the format is unrecognized.
+func (s *SiteProperties) CreatedTimeDate() time.Time {
+	return parseCSOMDate(s.CreatedTime)
+}
+
+// LastContentModifiedDateTime parses LastContentModifiedDate from CSOM date format into time.Time.
+// Returns the zero time if the format is unrecognized.
+func (s *SiteProperties) LastContentModifiedDateTime() time.Time {
+	return parseCSOMDate(s.LastContentModifiedDate)
+}
+
+// CleanSiteID returns the SiteID with any "/Guid(...)/" wrapper stripped.
+func (s *SiteProperties) CleanSiteID() string {
+	clean := strings.TrimPrefix(s.SiteID, "/Guid(")
+	clean = strings.TrimSuffix(clean, ")/")
+	return clean
+}
+
+// GetSiteProperties returns a filtered list of site collections and their properties using the
+// GetSitePropertiesFromSharePointByFilters CSOM method.
+// Results will include OneDrive personal sites when the filter's IncludePersonalSite is set.
+// For non-personal site queries, the sp.Web() and sp.Site() fluent methods are the recommended approach.
+func (t *SPOTenant) GetSiteProperties(filter *SitePropertiesFilter) (*SitePropertiesPage, error) {
+	if filter == nil {
+		filter = &SitePropertiesFilter{}
+	}
+	return t.getSitePropertiesPage(filter, "0")
+}
+
+func (t *SPOTenant) getSitePropertiesPage(filter *SitePropertiesFilter, startIndex string) (*SitePropertiesPage, error) {
+	csomPkg, err := buildSitePropertiesQuery(filter, startIndex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build CSOM query: %w", err)
+	}
+
+	jsomResp, err := t.client.ProcessQuery(t.endpoint, bytes.NewBuffer([]byte(csomPkg)), t.config)
+	if err != nil {
+		return nil, fmt.Errorf("CSOM query failed: %w", err)
+	}
+
+	resp, err := parseSitePropertiesResponse(jsomResp)
+	if err != nil {
+		return nil, err
+	}
+
+	nextStartIndex := resp.nextStartIndex
+	page := &SitePropertiesPage{
+		Sites: resp.sites,
+		HasNextPage: func() bool {
+			return strings.TrimSpace(nextStartIndex) != ""
+		},
+		GetNextPage: func() (*SitePropertiesPage, error) {
+			if strings.TrimSpace(nextStartIndex) == "" {
+				return nil, fmt.Errorf("no next page available")
+			}
+			return t.getSitePropertiesPage(filter, nextStartIndex)
+		},
+	}
+	return page, nil
+}
+
+// SPO Tenant CSOM TypeIDs
+const (
+	spoTenantTypeID              = "{268004ae-ef6b-4e9b-8425-127220d84719}"
+	spoSitePropertiesFilterTypeID = "{b92aeee2-c92c-4b67-abcc-024e471bc140}"
+)
+
+// buildSitePropertiesQuery constructs the CSOM XML for GetSitePropertiesFromSharePointByFilters
+func buildSitePropertiesQuery(filter *SitePropertiesFilter, startIndex string) (string, error) {
+	builder := csom.NewBuilder()
+
+	constructorXML := `<Constructor Id="{{.ID}}" TypeId="` + spoTenantTypeID + `" />`
+	tenantObject, _ := builder.AddObject(csom.NewObject(constructorXML), nil)
+
+	methodParams := []string{
+		fmt.Sprintf(`
+			<Parameter TypeId="%s">
+				<Property Name="Filter" Type="String">%s</Property>
+				<Property Name="IncludeDetail" Type="Boolean">%s</Property>
+				<Property Name="IncludePersonalSite" Type="Enum">%d</Property>
+				<Property Name="StartIndex" Type="String">%s</Property>
+				<Property Name="Template" Type="String">%s</Property>
+			</Parameter>`,
+			spoSitePropertiesFilterTypeID,
+			filter.Filter,
+			strings.ToLower(strconv.FormatBool(filter.IncludeDetail)),
+			filter.IncludePersonalSite,
+			startIndex,
+			filter.Template,
+		),
+	}
+
+	methodObject, _ := builder.AddObject(
+		csom.NewObjectMethod("GetSitePropertiesFromSharePointByFilters", methodParams),
+		tenantObject,
+	)
+
+	builder.AddAction(csom.NewAction(`<ObjectPath Id="{{.ID}}" ObjectPathId="{{.ObjectID}}" />`), tenantObject)
+	builder.AddAction(csom.NewAction(`<ObjectPath Id="{{.ID}}" ObjectPathId="{{.ObjectID}}" />`), methodObject)
+
+	queryXML := `<Query Id="{{.ID}}" ObjectPathId="{{.ObjectID}}">` +
+		`<Query SelectAllProperties="true"><Properties /></Query>` +
+		`<ChildItemQuery SelectAllProperties="true"><Properties /></ChildItemQuery>` +
+		`</Query>`
+	builder.AddAction(csom.NewAction(queryXML), methodObject)
+
+	return builder.Compile()
+}
+
+// sitePropertiesRawResponse holds the parsed CSOM response fields
+// before they are wrapped into a SitePropertiesPage.
+type sitePropertiesRawResponse struct {
+	nextStartIndex string
+	sites          []SitePropertiesResp
+}
+
+// parseSitePropertiesResponse parses the raw CSOM JSON array response
+func parseSitePropertiesResponse(data []byte) (*sitePropertiesRawResponse, error) {
+	var rawResponse []json.RawMessage
+	if err := json.Unmarshal(data, &rawResponse); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal CSOM response: %w", err)
+	}
+
+	if len(rawResponse) == 0 {
+		return nil, fmt.Errorf("empty CSOM response")
+	}
+
+	// The site data is in the last element of the response array
+	var envelope struct {
+		NextStartIndex string            `json:"NextStartIndexFromSharePoint"`
+		ChildItems     []json.RawMessage `json:"_Child_Items_"`
+	}
+	if err := json.Unmarshal(rawResponse[len(rawResponse)-1], &envelope); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal site properties envelope: %w", err)
+	}
+
+	sites := make([]SitePropertiesResp, len(envelope.ChildItems))
+	for i, raw := range envelope.ChildItems {
+		sites[i] = SitePropertiesResp(raw)
+	}
+
+	return &sitePropertiesRawResponse{
+		nextStartIndex: envelope.NextStartIndex,
+		sites:          sites,
+	}, nil
+}
+
+// csomDateRegex matches the CSOM date format: /Date(year,month,day,hour,min,sec,ms)/
+var csomDateRegex = regexp.MustCompile(`/Date\((\d+),(\d+),(\d+),(\d+),(\d+),(\d+),(\d+)\)/`)
+
+// parseCSOMDate parses a SharePoint CSOM date string "/Date(2024,0,15,10,30,0,0)/"
+// into a time.Time in UTC. The month field is zero based (0=January).
+// Returns the zero time if the input is malformed.
+func parseCSOMDate(input string) time.Time {
+	matches := csomDateRegex.FindStringSubmatch(input)
+	if len(matches) != 8 {
+		return time.Time{}
+	}
+
+	values := make([]int, 7)
+	for i := 0; i < 7; i++ {
+		n, err := strconv.Atoi(matches[i+1])
+		if err != nil {
+			return time.Time{}
+		}
+		values[i] = n
+	}
+
+	return time.Date(
+		values[0], time.Month(values[1]+1), values[2],
+		values[3], values[4], values[5], values[6]*1_000_000,
+		time.UTC,
+	)
+}

--- a/api/spotenant_test.go
+++ b/api/spotenant_test.go
@@ -1,0 +1,353 @@
+package api
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// csomSitePropertiesMock is a sample CSOM response from
+// GetSitePropertiesFromSharePointByFilters with two child items.
+const csomSitePropertiesMock = `[
+	{"SchemaVersion":"15.0.0.0","LibraryVersion":"16.0.27104.12006","ErrorInfo":null,"TraceCorrelationId":"a1b2c3d4-e5f6-7890-abcd-ef1234567890"},
+	3,
+	{"IsNull":false},
+	4,
+	{"IsNull":false},
+	5,
+	{
+		"_ObjectType_":"Microsoft.Online.SharePoint.TenantAdministration.SPOSitePropertiesEnumerable",
+		"NextStartIndex":-1,
+		"NextStartIndexFromSharePoint":"SPSiteQuery,d4e5f6a7-b8c9-0123-defa-234567890123,e5f6a7b8-c9d0-1234-efab-345678901234,f6a7b8c9-d0e1-2345-fabc-456789012345",
+		"_Child_Items_":[
+			{
+				"_ObjectType_":"Microsoft.Online.SharePoint.TenantAdministration.SiteProperties",
+				"_ObjectIdentity_":"a1b2c3d4-e5f6-7890-abcd-ef1234567890|b2c3d4e5-f6a7-8901-bcde-f12345678901:c3d4e5f6-a7b8-9012-cdef-123456789012\nSiteProperties\nhttps%3a%2f%2fcontoso-my.sharepoint.com%2fpersonal%2fjdoe_contoso_com",
+				"AllowDownloadingNonWebViewableFiles":false,
+				"AllowEditing":false,
+				"AllowSelfServiceUpgrade":true,
+				"CompatibilityLevel":15,
+				"ConditionalAccessPolicy":0,
+				"CreatedTime":"\/Date(2025,6,18,3,15,55,40)\/",
+				"DefaultLinkPermission":0,
+				"DefaultSharingLinkType":0,
+				"DenyAddAndCustomizePages":2,
+				"Description":null,
+				"GroupId":"\/Guid(00000000-0000-0000-0000-000000000000)\/",
+				"HasHolds":false,
+				"HubSiteId":"\/Guid(00000000-0000-0000-0000-000000000000)\/",
+				"IsHubSite":false,
+				"IsTeamsChannelConnected":false,
+				"IsTeamsConnected":false,
+				"LastContentModifiedDate":"\/Date(2026,2,20,5,1,7,280)\/",
+				"Lcid":1033,
+				"LockIssue":null,
+				"LockReason":0,
+				"LockState":"Unlock",
+				"Owner":"jdoe@contoso.com",
+				"OwnerEmail":null,
+				"OwnerLoginName":null,
+				"OwnerName":null,
+				"PWAEnabled":1,
+				"RelatedGroupId":"\/Guid(00000000-0000-0000-0000-000000000000)\/",
+				"SensitivityLabel":"\/Guid(00000000-0000-0000-0000-000000000000)\/",
+				"SharingCapability":2,
+				"SharingDomainRestrictionMode":0,
+				"SiteDefinedSharingCapability":2,
+				"SiteId":"\/Guid(a7b8c9d0-e1f2-3456-abcd-567890123456)\/",
+				"Status":"Active",
+				"StorageMaximumLevel":1048576,
+				"StorageQuotaType":null,
+				"StorageUsage":42,
+				"StorageWarningLevel":943718,
+				"Template":"SPSPERS#12",
+				"TeamsChannelType":0,
+				"Title":"John Doe",
+				"Url":"https:\u002f\u002fcontoso-my.sharepoint.com\u002fpersonal\u002fjdoe_contoso_com",
+				"WebsCount":0
+			},
+			{
+				"_ObjectType_":"Microsoft.Online.SharePoint.TenantAdministration.SiteProperties",
+				"_ObjectIdentity_":"a1b2c3d4-e5f6-7890-abcd-ef1234567890|b2c3d4e5-f6a7-8901-bcde-f12345678901:c3d4e5f6-a7b8-9012-cdef-123456789012\nSiteProperties\nhttps%3a%2f%2fcontoso-my.sharepoint.com%2fpersonal%2fasmith_contoso_com",
+				"AllowDownloadingNonWebViewableFiles":false,
+				"AllowEditing":false,
+				"AllowSelfServiceUpgrade":true,
+				"CompatibilityLevel":15,
+				"ConditionalAccessPolicy":0,
+				"CreatedTime":"\/Date(2024,3,10,14,22,30,0)\/",
+				"DefaultLinkPermission":0,
+				"DefaultSharingLinkType":0,
+				"DenyAddAndCustomizePages":2,
+				"Description":null,
+				"GroupId":"\/Guid(00000000-0000-0000-0000-000000000000)\/",
+				"HasHolds":false,
+				"HubSiteId":"\/Guid(00000000-0000-0000-0000-000000000000)\/",
+				"IsHubSite":false,
+				"IsTeamsChannelConnected":false,
+				"IsTeamsConnected":false,
+				"LastContentModifiedDate":"\/Date(2026,1,15,12,0,0,0)\/",
+				"Lcid":1033,
+				"LockIssue":null,
+				"LockReason":0,
+				"LockState":"Unlock",
+				"Owner":"asmith@contoso.com",
+				"OwnerEmail":null,
+				"OwnerLoginName":null,
+				"OwnerName":null,
+				"PWAEnabled":1,
+				"RelatedGroupId":"\/Guid(00000000-0000-0000-0000-000000000000)\/",
+				"SensitivityLabel":"\/Guid(00000000-0000-0000-0000-000000000000)\/",
+				"SharingCapability":2,
+				"SharingDomainRestrictionMode":0,
+				"SiteDefinedSharingCapability":2,
+				"SiteId":"\/Guid(b8c9d0e1-f2a3-4567-bcde-678901234567)\/",
+				"Status":"Active",
+				"StorageMaximumLevel":1048576,
+				"StorageQuotaType":null,
+				"StorageUsage":8192,
+				"StorageWarningLevel":943718,
+				"Template":"SPSPERS#12",
+				"TeamsChannelType":0,
+				"Title":"Alice Smith",
+				"Url":"https:\u002f\u002fcontoso-my.sharepoint.com\u002fpersonal\u002fasmith_contoso_com",
+				"WebsCount":0
+			}
+		]
+	}
+]`
+
+func TestBuildSitePropertiesQuery(t *testing.T) {
+	filter := &SitePropertiesFilter{
+		Filter:              "Url -like 'contoso-my.sharepoint.com/personal/'",
+		IncludePersonalSite: IncludePersonalSiteInclude,
+		Template:            "SPSPERS",
+	}
+
+	xml, err := buildSitePropertiesQuery(filter, "0")
+	if err != nil {
+		t.Fatalf("buildSitePropertiesQuery: %v", err)
+	}
+	if xml == "" {
+		t.Fatal("expected non-empty XML")
+	}
+
+	for _, want := range []string{
+		"contoso-my.sharepoint.com/personal/",
+		"SPSPERS",
+		"GetSitePropertiesFromSharePointByFilters",
+		spoTenantTypeID,
+		spoSitePropertiesFilterTypeID,
+	} {
+		if !strings.Contains(xml, want) {
+			t.Errorf("XML should contain %q", want)
+		}
+	}
+}
+
+
+func TestParseSitePropertiesResponse(t *testing.T) {
+	t.Run("mocked response", func(t *testing.T) {
+		result, err := parseSitePropertiesResponse([]byte(csomSitePropertiesMock))
+		if err != nil {
+			t.Fatalf("parseSitePropertiesResponse: %v", err)
+		}
+
+		// Pagination token
+		if strings.TrimSpace(result.nextStartIndex) == "" {
+			t.Error("nextStartIndex should be non-empty for continuation token")
+		}
+		if !strings.HasPrefix(result.nextStartIndex, "SPSiteQuery,") {
+			t.Errorf("nextStartIndex should start with 'SPSiteQuery,', got %q", result.nextStartIndex[:20])
+		}
+
+		// Child items count
+		if len(result.sites) != 2 {
+			t.Fatalf("len(sites) = %d, want 2", len(result.sites))
+		}
+
+		// First site  - verify Data() unmarshals correctly
+		site := result.sites[0].Data()
+		if site.Title != "John Doe" {
+			t.Errorf("Title = %q, want %q", site.Title, "John Doe")
+		}
+		if site.URL != "https://contoso-my.sharepoint.com/personal/jdoe_contoso_com" {
+			t.Errorf("URL = %q, want decoded unicode path", site.URL)
+		}
+		if site.Owner != "jdoe@contoso.com" {
+			t.Errorf("Owner = %q, want %q", site.Owner, "jdoe@contoso.com")
+		}
+		if site.Template != "SPSPERS#12" {
+			t.Errorf("Template = %q, want %q", site.Template, "SPSPERS#12")
+		}
+		if site.LockState != "Unlock" {
+			t.Errorf("LockState = %q, want %q", site.LockState, "Unlock")
+		}
+		if site.StorageUsage != 42 {
+			t.Errorf("StorageUsage = %d, want 42", site.StorageUsage)
+		}
+		if site.SiteID != "/Guid(a7b8c9d0-e1f2-3456-abcd-567890123456)/" {
+			t.Errorf("SiteID = %q, want wrapped GUID", site.SiteID)
+		}
+		if site.CleanSiteID() != "a7b8c9d0-e1f2-3456-abcd-567890123456" {
+			t.Errorf("CleanSiteID() = %q, want unwrapped GUID", site.CleanSiteID())
+		}
+
+		// CSOM date parsing  - CreatedTime: /Date(2025,6,18,3,15,55,40)/ = July 18, 2025
+		wantCreated := time.Date(2025, time.July, 18, 3, 15, 55, 40_000_000, time.UTC)
+		if got := site.CreatedTimeDate(); !got.Equal(wantCreated) {
+			t.Errorf("CreatedTimeDate() = %v, want %v", got, wantCreated)
+		}
+
+		// LastContentModifiedDate: /Date(2026,2,20,5,1,7,280)/ = March 20, 2026
+		wantModified := time.Date(2026, time.March, 20, 5, 1, 7, 280_000_000, time.UTC)
+		if got := site.LastContentModifiedDateTime(); !got.Equal(wantModified) {
+			t.Errorf("LastContentModifiedDateTime() = %v, want %v", got, wantModified)
+		}
+
+		// Normalized() returns raw bytes for custom unmarshalling
+		raw := result.sites[0].Normalized()
+		if len(raw) == 0 {
+			t.Error("Normalized() should return non-empty bytes")
+		}
+
+		// Second site - verify Data() unmarshals correctly
+		site2 := result.sites[1].Data()
+		if site2.Title != "Alice Smith" {
+			t.Errorf("sites[1].Title = %q, want %q", site2.Title, "Alice Smith")
+		}
+		if site2.URL != "https://contoso-my.sharepoint.com/personal/asmith_contoso_com" {
+			t.Errorf("sites[1].URL = %q, want decoded unicode path", site2.URL)
+		}
+		if site2.Owner != "asmith@contoso.com" {
+			t.Errorf("sites[1].Owner = %q, want %q", site2.Owner, "asmith@contoso.com")
+		}
+		if site2.Template != "SPSPERS#12" {
+			t.Errorf("sites[1].Template = %q, want %q", site2.Template, "SPSPERS#12")
+		}
+		if site2.LockState != "Unlock" {
+			t.Errorf("sites[1].LockState = %q, want %q", site2.LockState, "Unlock")
+		}
+		if site2.StorageUsage != 8192 {
+			t.Errorf("sites[1].StorageUsage = %d, want 8192", site2.StorageUsage)
+		}
+		if site2.SiteID != "/Guid(b8c9d0e1-f2a3-4567-bcde-678901234567)/" {
+			t.Errorf("sites[1].SiteID = %q, want wrapped GUID", site2.SiteID)
+		}
+		if site2.CleanSiteID() != "b8c9d0e1-f2a3-4567-bcde-678901234567" {
+			t.Errorf("sites[1].CleanSiteID() = %q, want unwrapped GUID", site2.CleanSiteID())
+		}
+
+		// CSOM date parsing - CreatedTime: /Date(2024,3,10,14,22,30,0)/ = April 10, 2024
+		wantCreated2 := time.Date(2024, time.April, 10, 14, 22, 30, 0, time.UTC)
+		if got := site2.CreatedTimeDate(); !got.Equal(wantCreated2) {
+			t.Errorf("sites[1].CreatedTimeDate() = %v, want %v", got, wantCreated2)
+		}
+
+		// LastContentModifiedDate: /Date(2026,1,15,12,0,0,0)/ = February 15, 2026
+		wantModified2 := time.Date(2026, time.February, 15, 12, 0, 0, 0, time.UTC)
+		if got := site2.LastContentModifiedDateTime(); !got.Equal(wantModified2) {
+			t.Errorf("sites[1].LastContentModifiedDateTime() = %v, want %v", got, wantModified2)
+		}
+
+		raw2 := result.sites[1].Normalized()
+		if len(raw2) == 0 {
+			t.Error("sites[1].Normalized() should return non-empty bytes")
+		}
+	})
+
+	t.Run("no more pages", func(t *testing.T) {
+		input := `[
+			{"SchemaVersion":"15.0.0.0","LibraryVersion":"16.0.27104.12006","ErrorInfo":null,"TraceCorrelationId":"abc-123"},
+			3,
+			{"IsNull":false},
+			4,
+			{"IsNull":false},
+			5,
+			{"_ObjectType_":"Microsoft.Online.SharePoint.TenantAdministration.SPOSitePropertiesEnumerable","NextStartIndex":-1,"NextStartIndexFromSharePoint":"","_Child_Items_":[]}
+		]`
+		result, err := parseSitePropertiesResponse([]byte(input))
+		if err != nil {
+			t.Fatalf("parseSitePropertiesResponse: %v", err)
+		}
+		if strings.TrimSpace(result.nextStartIndex) != "" {
+			t.Error("nextStartIndex should be empty for last page")
+		}
+		if len(result.sites) != 0 {
+			t.Errorf("len(sites) = %d, want 0", len(result.sites))
+		}
+	})
+
+	t.Run("empty array", func(t *testing.T) {
+		_, err := parseSitePropertiesResponse([]byte(`[]`))
+		if err == nil {
+			t.Error("expected error for empty array")
+		}
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		_, err := parseSitePropertiesResponse([]byte(`not json`))
+		if err == nil {
+			t.Error("expected error for invalid json")
+		}
+	})
+}
+
+func TestParseCSOMDate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  time.Time
+	}{
+		{
+			"mocked created time from CSOM response",
+			"/Date(2025,6,18,3,15,55,40)/",
+			time.Date(2025, time.July, 18, 3, 15, 55, 40_000_000, time.UTC),
+		},
+		{
+			"mocked modified time from CSOM response",
+			"/Date(2026,2,20,5,1,7,280)/",
+			time.Date(2026, time.March, 20, 5, 1, 7, 280_000_000, time.UTC),
+		},
+		{
+			"december boundary",
+			"/Date(2024,11,31,23,59,59,999)/",
+			time.Date(2024, time.December, 31, 23, 59, 59, 999_000_000, time.UTC),
+		},
+		{
+			"january zero-based month",
+			"/Date(2024,0,15,10,30,0,0)/",
+			time.Date(2024, time.January, 15, 10, 30, 0, 0, time.UTC),
+		},
+		{"empty string", "", time.Time{}},
+		{"missing fields", "/Date(2024,0,15)/", time.Time{}},
+		{"non-numeric", "/Date(abc,0,15,10,30,0,0)/", time.Time{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseCSOMDate(tt.input)
+			if !got.Equal(tt.want) {
+				t.Errorf("parseCSOMDate(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSitePropertiesCleanSiteID(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"CSOM format", "/Guid(a7b8c9d0-e1f2-3456-abcd-567890123456)/", "a7b8c9d0-e1f2-3456-abcd-567890123456"},
+		{"already clean", "a7b8c9d0-e1f2-3456-abcd-567890123456", "a7b8c9d0-e1f2-3456-abcd-567890123456"},
+		{"empty", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sp := &SiteProperties{SiteID: tt.input}
+			if got := sp.CleanSiteID(); got != tt.want {
+				t.Errorf("CleanSiteID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Summary

This PR adds a `SPOTenant` object to the Fluent API which can be used to query site collection properties via the SharePoint Online Tenant Administration CSOM API method (`GetSitePropertiesFromSharePointByFilters`). 

The `GetSitePropertiesFromSharePointByFilters`  method allows for enumeration of personal sites (OneDrive) without needing to rely on the Search API.

I went with the generic `SPOTenant` name as over time there are likely to be other Tenant Admin API methods that would be worth implementing.

Related to: #79 - I ended up moving to this approach following my original queries.
                                                
### Changes
  
**Files added:**

- **`api/spotenant.go`**: Adds `SPOTenant` type and `GetSiteProperties` for enumerating site collections (including OneDrive/personal sites) via the Tenant Administration CSOM API. `SiteProperties` struct fields map to `Microsoft.Online.SharePoint.TenantAdministration.SiteProperties`.
- **`api/spotenant_test.go`**: Unit tests for query building/parsing/marshalling.

**Files changed:**

- **`api/sp.go`**: Added `SP.SPOTenant()` getter for fluent API access.

I've included `Data()` for typed unmarshalling to `SiteProperties` and `Normalized()` for raw JSON, and I've implemented `HasNextPage()`/`GetNextPage()` for pagination.

### Example
```
func main() {
	client := &gosip.SPClient{
		AuthCnfg: &strategy.AuthCnfg{
			// Tenant admin URL
			SiteURL: "https://contoso-admin.sharepoint.com",
			// ...
		},
	}

	sp := api.NewSP(client)
	tenant := sp.SPOTenant()

	page, err := tenant.GetSiteProperties(&api.SitePropertiesFilter{
		IncludePersonalSite: api.IncludePersonalSiteInclude,
		Template:            "SPSPERS",
	})
	if err != nil {
		log.Fatal(err)
	}

	for {
		for _, site := range page.Sites {
			fmt.Printf("%s - %s (%d MB)\n", site.Data().Title, site.Data().URL, site.Data().StorageUsage)
		}
		if !page.HasNextPage() {
			break
		}
		page, err = page.GetNextPage()
		if err != nil {
			log.Fatal(err)
		}
	}
}
```

### Testing

As above, tests are included in `api/spotenant_test.go`.